### PR TITLE
Full italian translation update

### DIFF
--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -5,35 +5,35 @@
     <name>AddPeerDialog</name>
     <message>
         <source>Add Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi Peer</translation>
     </message>
     <message>
         <source>Enter the peer details below.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci i dettagli del peer.</translation>
     </message>
     <message>
         <source>Be careful! Do not blindly trust anyone that tells you to add their node.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fai attenzione! Non fidarti ciecamente di qualcuno che ti chiede di aggiungere il suo nodo.</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s address</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi l&apos;indirizzo del peer</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s port</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi la porta del peer</translation>
     </message>
     <message>
         <source>Add!</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi!</translation>
     </message>
     <message>
         <source>Please enter an address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserici un indirizzo.</translation>
     </message>
     <message>
         <source>Please enter a valid peer address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un indirizzo valido per il peer.</translation>
     </message>
 </context>
 <context>
@@ -170,27 +170,27 @@
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Inserisci la nuova passphrase per il portamonete.&lt;br/&gt;Si consiglia di utilizzare &lt;b&gt;almeno dieci caratteri casuali&lt;/b&gt; oppure &lt;b&gt;otto o più parole&lt;/b&gt;.</translation>
+        <translation>Inserisci la nuova passphrase per il portafoglio.&lt;br/&gt;Si consiglia di utilizzare &lt;b&gt;almeno dieci caratteri casuali&lt;/b&gt; oppure &lt;b&gt;otto o più parole&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation>Cifra il portamonete</translation>
+        <translation>Cifra il portafoglio</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation>Questa operazione necessita della passphrase per sbloccare il portamonete.</translation>
+        <translation>Questa operazione necessita della passphrase per sbloccare il portafoglio.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation>Sblocca il portamonete</translation>
+        <translation>Sblocca il portafoglio</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation>Quest&apos;operazione necessita della passphrase per decifrare il portamonete,</translation>
+        <translation>Quest&apos;operazione necessita della passphrase per decifrare il portafoglio,</translation>
     </message>
     <message>
         <source>Decrypt wallet</source>
-        <translation>Decifra il portamonete</translation>
+        <translation>Decifra il portafoglio</translation>
     </message>
     <message>
         <source>Change passphrase</source>
@@ -198,19 +198,19 @@
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase to the wallet.</source>
-        <translation>Inserisci la vecchia e la nuova passphrase per il portamonete.</translation>
+        <translation>Inserisci la vecchia e la nuova passphrase per il portafoglio.</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation>Conferma la cifratura del portamonete</translation>
+        <translation>Conferma la cifratura del portafoglio</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR DOGECOINS&lt;/b&gt;!</source>
-        <translation>Attenzione: se si cifra il portamonete e si perde la passphrase &lt;b&gt;TUTTI I PROPRI Dogecoin ANDRANNO PERSI&lt;/b&gt;!</translation>
+        <translation>Attenzione: se si cifra il portafoglio e si perde la passphrase &lt;b&gt;TUTTI I PROPRI Dogecoin ANDRANNO PERSI&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation>Si è sicuri di voler cifrare il portamonete?</translation>
+        <translation>Si è sicuri di voler cifrare il portafoglio?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
@@ -218,7 +218,7 @@
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: qualsiasi backup del file portamonete effettuato in precedenza dovrà essere sostituito con il file del portamonete cifrato appena generato. Per ragioni di sicurezza, i precedenti backup del file del portamonete non cifrato diventeranno inservibili non appena si inizierà ad utilizzare il nuovo portamonete cifrato.</translation>
+        <translation>IMPORTANTE: qualsiasi backup del file portafoglio effettuato in precedenza dovrà essere sostituito con il file del portafoglio cifrato appena generato. Per ragioni di sicurezza, i precedenti backup del file del portafoglio non cifrato diventeranno inservibili non appena si inizierà ad utilizzare il nuovo portafoglio cifrato.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -226,7 +226,7 @@
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation>Crittaggio fallito a causa di un errore interno. Il portamonete non è stato crittato.</translation>
+        <translation>Crittaggio fallito a causa di un errore interno. Il portafoglio non è stato crittato.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -242,11 +242,11 @@
     </message>
     <message>
         <source>Wallet decryption failed</source>
-        <translation>Decrittazione del portamonete fallita.</translation>
+        <translation>Decrittazione del portafoglio fallita.</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation>La frase di accesso al portamonete è stata cambiata con successo.</translation>
+        <translation>La frase di accesso al portafoglio è stata cambiata con successo.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your dogecoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 si chiuderá per completare il processo di cifratura. Ricordati che cifrare il portafoglio potrebbe non proteggere i tuoi dogecoin nel caso in cui il tuo computer sia infetto da malware.</translation>
     </message>
 </context>
 <context>
@@ -288,7 +288,7 @@
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>Mostra lo stato generale del portamonete</translation>
+        <translation>Mostra lo stato generale del portafoglio</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -332,11 +332,11 @@
     </message>
     <message>
         <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Cifra il portamonete...</translation>
+        <translation>&amp;Cifra il portafoglio...</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Backup portamonete...</translation>
+        <translation>&amp;Backup portafoglio...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase...</source>
@@ -356,11 +356,11 @@
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>Effettua il backup del portamonete</translation>
+        <translation>Effettua il backup del portafoglio</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>Cambia la passphrase utilizzata per la cifratura del portamonete</translation>
+        <translation>Cambia la passphrase utilizzata per la cifratura del portafoglio</translation>
     </message>
     <message>
         <source>&amp;Debug window</source>
@@ -400,7 +400,7 @@
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>Cifra le chiavi private che appartengono al tuo portamonete</translation>
+        <translation>Cifra le chiavi private che appartengono al tuo portafoglio</translation>
     </message>
     <message>
         <source>Sign messages with your Dogecoin addresses to prove you own them</source>
@@ -548,78 +548,78 @@
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;sbloccato&lt;/b&gt;</translation>
+        <translation>Il portafoglio è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;sbloccato&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;bloccato&lt;/b&gt;</translation>
+        <translation>Il portafoglio è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;bloccato&lt;/b&gt;</translation>
     </message>
     <message>
         <source>&amp;Print paper wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Stampa portafogli di carta</translation>
     </message>
     <message>
         <source>Print paper wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Stampa portafogli di carta</translation>
     </message>
     <message>
         <source>&amp;Such sending addresses...</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzi di invio</translation>
     </message>
     <message>
         <source>&amp;Much receiving addresses...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Indirizzi di ricezione</translation>
     </message>
     <message>
         <source>&amp;Import Private Key...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importa chiave privata</translation>
     </message>
     <message>
         <source>Import a Dogecoin private key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importa una chiave privata</translation>
     </message>
     <message>
         <source>Click to disable network activity.</source>
-        <translation type="unfinished"></translation>
+        <translation>Clicca per disabilitare attività di rete.</translation>
     </message>
     <message>
         <source>Network activity disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Attività di rete disabilitata.</translation>
     </message>
     <message>
         <source>Click to enable network activity again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Clicca per riabilitare attività di rete.</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sincronizzazione Headers (%1%)...</translation>
     </message>
     <message>
         <source>Connecting to peers...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connessione ai peers in corso...</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>La creazione della chiave HD è &lt;b&gt;abilitata&lt;/b&gt;</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>La creazione della chiave HD è &lt;b&gt;disabilitata&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Runaway exception</source>
-        <translation type="unfinished"></translation>
+        <translation>Eccezione runaway</translation>
     </message>
     <message>
         <source>A fatal error occurred. Dogecoin can no longer continue safely and will quit.</source>
-        <translation type="unfinished"></translation>
+        <translation>Si è verificato un errore critico. Dogecoin non può più continuare ad operare in sicurezza e verrà chiuso.</translation>
     </message>
 </context>
 <context>
     <name>ClientModel</name>
     <message>
         <source>Network Alert</source>
-        <translation type="unfinished"></translation>
+        <translation>Avviso di Rete</translation>
     </message>
 </context>
 <context>
@@ -646,7 +646,7 @@
     </message>
     <message>
         <source>Dust:</source>
-        <translation>Trascurabile:</translation>
+        <translation>Polvere (dust):</translation>
     </message>
     <message>
         <source>After Fee:</source>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <source>Copy dust</source>
-        <translation>Copia trascurabile</translation>
+        <translation>Copia polvere</translation>
     </message>
     <message>
         <source>Copy change</source>
@@ -770,7 +770,7 @@
     </message>
     <message>
         <source>Can vary +/- %1 koinu(s) per input.</source>
-        <translation type="unfinished"></translation>
+        <translation>può variare di +/- %1 koinu per input.</translation>
     </message>
 </context>
 <context>
@@ -821,7 +821,7 @@
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation>Impossibile sbloccare il portamonete.</translation>
+        <translation>Impossibile sbloccare il portafoglio.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
@@ -910,63 +910,63 @@
     <name>ImportKeysDialog</name>
     <message>
         <source>Import Private Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importa Chiave Privata</translation>
     </message>
     <message>
         <source>&amp;Import Private Key</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importa Chiave Privata</translation>
     </message>
     <message>
         <source>Private Key:</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiave Privata:</translation>
     </message>
     <message>
         <source>Private key to import into your wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiave privata da importare nel tuo portafoglio.</translation>
     </message>
     <message>
         <source>Label for this private key in your wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Etichetta della chiave privata nel tuo portofoglio.</translation>
     </message>
     <message>
         <source>Label (optional):</source>
-        <translation type="unfinished"></translation>
+        <translation>Etichetta (opzionale):</translation>
     </message>
     <message>
         <source>Rescan</source>
-        <translation type="unfinished"></translation>
+        <translation>Ripeti scansione</translation>
     </message>
     <message>
         <source>Reset all key management options to default.</source>
-        <translation type="unfinished"></translation>
+        <translation>Resetta tutte le opzioni di gestione delle chiavi</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Resetta</translation>
     </message>
     <message>
         <source>&amp;Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importa</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancella</translation>
+        <translation>&amp;Cancella</translation>
     </message>
     <message>
         <source>Invalid private key; please check and try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiave privata non valida; controlla e prova di nuovo!</translation>
     </message>
     <message>
         <source>Invalid address generated from private key; please check and try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;indirizzo generato dalla chiave privata non è valido; controlla e prova di nuovo!</translation>
     </message>
     <message>
         <source>Failed to add private key.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible importare la chiave privata.</translation>
     </message>
     <message>
         <source>Rescanning...</source>
-        <translation type="unfinished">Ripetizione scansione...</translation>
+        <translation>Ripetizione scansione...</translation>
     </message>
 </context>
 <context>
@@ -1019,7 +1019,7 @@
     </message>
     <message>
         <source>Choose data directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Scegli la cartella dati</translation>
     </message>
 </context>
 <context>
@@ -1050,27 +1050,27 @@
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the dogecoin network, as detailed below.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le transazioni recenti potrebbero non essere ancora visibili, quindi il saldo totale del tuo portafoglio potrebbe non essere corretto. Il saldo risulterà corretto quando il tuo portafoglio avrà completato la sincronizzazione con la rete dogecoin, come indicato più sotto.</translation>
     </message>
     <message>
         <source>Attempting to spend dogecoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il tentativo di spendere dogecoin legati a transazioni non ancora visualizzate non verrà accettato dalla rete</translation>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished"></translation>
+        <translation>Progresso orario</translation>
     </message>
     <message>
         <source>calculating...</source>
-        <translation type="unfinished"></translation>
+        <translation>calcolando...</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo mancante stimato al completamento della sincronizzazione</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1)...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sconosciuto. Sincronizzazione headers in corso (%1,%2%)…</translation>
     </message>
 </context>
 <context>
@@ -1340,7 +1340,7 @@ Per specificare più URL separarli con una barra verticale &quot;|&quot;.</trans
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Le informazioni visualizzate potrebbero non essere aggiornate. Il portamonete si sincronizza automaticamente con la rete Dogecoin una volta stabilita una connessione, ma questo processo non è ancora stato completato.</translation>
+        <translation>Le informazioni visualizzate potrebbero non essere aggiornate. Il portafoglio si sincronizza automaticamente con la rete Dogecoin una volta stabilita una connessione, ma questo processo non è ancora stato completato.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
@@ -1408,118 +1408,118 @@ Per specificare più URL separarli con una barra verticale &quot;|&quot;.</trans
     </message>
     <message>
         <source>Helpful tip of the day:</source>
-        <translation type="unfinished"></translation>
+        <translation>Suggerimento utile del giorno:</translation>
     </message>
     <message>
         <source>Tip</source>
-        <translation type="unfinished"></translation>
+        <translation>Suggerimento</translation>
     </message>
     <message>
         <source>Never share your wallet.dat file/your private key with anyone</source>
-        <translation type="unfinished"></translation>
+        <translation>Non condividere mai con nessuno il tuo file wallet.dat o la tua chiave privata.</translation>
     </message>
     <message>
         <source>For more advanced settings use the console in &apos;Help&apos; -&gt; &apos;Debug Window&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Per accedere alle impostazioni avanzate usa la console tramite il menu &apos;Aiuto&apos; -&gt; &apos;Finestra di debug&apos;</translation>
     </message>
     <message>
         <source>Encrypt your wallet with a strong passphrase for maximum security</source>
-        <translation type="unfinished"></translation>
+        <translation>Cifra il portafoglio con una password complessa per maggior sicurezza.</translation>
     </message>
     <message>
         <source>Make sure to keep your wallet updated.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ricordati di aggiornare il tuo portafoglio.</translation>
     </message>
     <message>
         <source>Backup your private key to recover your coins, using &apos;File&apos; &gt; &apos;Backup Wallet&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fai un backup delle tue chiavi private usando il menu &apos;File&apos; &gt; &apos;Backup Portamonete&apos; </translation>
     </message>
     <message>
         <source>Always do your own research before using an external cryptocurrency service</source>
-        <translation type="unfinished"></translation>
+        <translation>Fai le dovute ricerche prima di utilizzare qualsiasi servizio criptovalute.</translation>
     </message>
     <message>
         <source>Never share your private key to an untrustworthy person.</source>
-        <translation type="unfinished"></translation>
+        <translation>Non condividere mai la tua chiave privata con una persona di cui non ti puoi fidare.</translation>
     </message>
     <message>
         <source>Who own the private keys own the coins.</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiunque abbia accesso alla chiave privata ha il controllo totale sul portafoglio.</translation>
     </message>
     <message>
         <source>To see ongoing development and contribute, checkout Dogecoin repository on GitHub!</source>
-        <translation type="unfinished"></translation>
+        <translation>Per essere aggiornato sullo sviluppo di Dogecoin e contribuire, segui il repository su GitHub!</translation>
     </message>
     <message>
         <source>Services that claim to double your dogecoins are always ponzi schemes</source>
-        <translation type="unfinished"></translation>
+        <translation>Tutti i servizi che promettono di moltiplicare i tuoi Dogecoin sono delle truffe.</translation>
     </message>
 </context>
 <context>
     <name>PaperWalletDialog</name>
     <message>
         <source>Print Your Paper Wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Stampa il tuo Portafoglio Cartaceo</translation>
     </message>
     <message>
         <source>Very New Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuovo Indirizzo</translation>
     </message>
     <message>
         <source>So Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Stampa</translation>
     </message>
     <message>
         <source>Many Wallets?</source>
-        <translation type="unfinished"></translation>
+        <translation>Portafogli</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="unfinished"></translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>2</source>
-        <translation type="unfinished"></translation>
+        <translation>2</translation>
     </message>
     <message>
         <source>3</source>
-        <translation type="unfinished"></translation>
+        <translation>3</translation>
     </message>
     <message>
         <source>4</source>
-        <translation type="unfinished"></translation>
+        <translation>4</translation>
     </message>
     <message>
         <source>5</source>
-        <translation type="unfinished"></translation>
+        <translation>5</translation>
     </message>
     <message>
         <source>6</source>
-        <translation type="unfinished"></translation>
+        <translation>6</translation>
     </message>
     <message>
         <source>7</source>
-        <translation type="unfinished"></translation>
+        <translation>7</translation>
     </message>
     <message>
         <source>8</source>
-        <translation type="unfinished"></translation>
+        <translation>8</translation>
     </message>
     <message>
         <source>9</source>
-        <translation type="unfinished"></translation>
+        <translation>9</translation>
     </message>
     <message>
         <source>10</source>
-        <translation type="unfinished"></translation>
+        <translation>10</translation>
     </message>
     <message>
         <source>11</source>
-        <translation type="unfinished"></translation>
+        <translation>11</translation>
     </message>
     <message>
         <source>12</source>
-        <translation type="unfinished"></translation>
+        <translation>12</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1531,103 +1531,103 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Public Key:</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiave Pubblica:</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiudi</translation>
     </message>
     <message>
         <source>Warning: Network Activity Detected</source>
-        <translation type="unfinished"></translation>
+        <translation>Attenzione: rilevata attività di rete</translation>
     </message>
     <message>
         <source>It is recommended to disconnect from the internet before printing paper wallets. Even though paper wallets are generated on your local computer, it is still possible to unknowingly have malware that transmits your screen to a remote location. It is also recommended to print to a local printer vs a network printer since that network traffic can be monitored. Some advanced printers also store copies of each printed document. Proceed with caution relative to the amount of value you plan to store on each address.</source>
-        <translation type="unfinished"></translation>
+        <translation>È preferibile disconnettersi dalla rete internet prima di stampare un portafoglio di carta. Anche se i portafogli di carta sono generati localmente nel tuo computer, è possibile che un malware nascosto nel tuo computer trasmetta remotamente immagini del tuo schermo. Si raccomanda di stampare il portafoglio utilizzando una stampante connessa direttamente al computer; il traffico di una rete locale può essere monitorato. Alcune stampanti più avanzate possono anche salvare localmente copie dei documenti stampati. Fai inoltre attenzione a limitare l&apos;importo contenuto in un singolo indirizzo.</translation>
     </message>
     <message>
         <source>Error encoding Address into QR Code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore nella codifica dell&apos;indirizzo nel codice QR.</translation>
     </message>
     <message>
         <source>Error encoding private key into QR Code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore nella codifica della chiave privata nel codice QR.</translation>
     </message>
     <message>
         <source>Printing Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore di stampa</translation>
     </message>
     <message>
         <source>failed to open file, is it writable?</source>
-        <translation type="unfinished"></translation>
+        <translation>impossibile aprire il file, controlla i permessi.</translation>
     </message>
     <message>
         <source>Load Paper Wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Carica Portafogli di Carta</translation>
     </message>
     <message>
         <source>The paper wallet printing process has begun.&lt;br/&gt;Please wait for the wallets to print completely and verify that everything printed correctly.&lt;br/&gt;Check for misalignments, ink bleeding, smears, or anything else that could make the private keys unreadable.&lt;br/&gt;Now, enter the number of DOGE you wish to send to each wallet:</source>
-        <translation type="unfinished"></translation>
+        <translation>Il processo di stampa del portafoglio di carta è iniziato.&lt;br/&gt;Attendi che la stampa sia completa; successivamente, verifica che non ci siano stati errori di stampa.&lt;br/&gt;Controlla che non ci siano distorsioni, macchie, o problemi che potrebbero rendere il portafoglio cartaceo illegibile.&lt;br/&gt;Ora inserisci la quantità di DOGE che vuoi inviare all&apos;indirizzo di ciascun portafoglio:</translation>
     </message>
     <message>
         <source>Paper wallet %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Portafoglio di carta %1</translation>
     </message>
     <message>
         <source>&lt;b&gt;%1&lt;/b&gt; to Paper Wallet &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; al Portafoglio di carta &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</translation>
     </message>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Invia Dogecoin</translation>
+        <translation>Invia Dogecoin</translation>
     </message>
     <message>
         <source>The recipient address is not valid, please recheck.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;indirizzo del destinatario non é valido, controlla di nuovo.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;importo da inviare deve essere superiore a 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">Non hai abbastanza fondi</translation>
+        <translation>Non hai abbastanza fondi</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the transaction fee is included</source>
-        <translation type="unfinished"></translation>
+        <translation>Il totale inclusivo delle commissioni di transazione è superiore al saldo disponibile</translation>
     </message>
     <message>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo già inserito. Puoi inviare Dogecoin allo stesso indirizzo solo una volta nella stessa operazione.</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">Creazione della transazione fallita!</translation>
+        <translation>Creazione della transazione fallita!</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sei sicuto di voler inviare?</translation>
     </message>
     <message>
         <source>added as transaction fee</source>
-        <translation type="unfinished"> Includi il costo della transazione</translation>
+        <translation> aggiunti come commissioni di transazione</translation>
     </message>
     <message>
         <source>Total Amount %1 (= %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Importo Totale %1 (= %2)</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished">o</translation>
+        <translation>o</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma l&apos;invio</translation>
     </message>
     <message>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation type="unfinished"></translation>
+        <translation>La transazione é stata rifiutata! Questo potrebbe accadere nel caso in cui alcuni dei tuoi fondi siano stati giá spesi, per esempio se hai usato una copia del file wallet.dat altrove e i fondi sono stati spesi nella copia ma non ancora registrati come spesi in questa installazione.</translation>
     </message>
 </context>
 <context>
@@ -1710,15 +1710,15 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Bad response from server %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Risposta non valida dal server %1</translation>
     </message>
     <message>
         <source>Network request error</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore di rete</translation>
     </message>
     <message>
         <source>Requested payment amount of %1 is too small (below discard threshold).</source>
-        <translation type="unfinished"></translation>
+        <translation>Il pagamento richiesto di %1 é troppo basso.</translation>
     </message>
 </context>
 <context>
@@ -1737,42 +1737,42 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>NodeId</source>
-        <translation type="unfinished"></translation>
+        <translation>Id Nodo</translation>
     </message>
     <message>
         <source>Bytes Sent</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes Inviati</translation>
     </message>
     <message>
         <source>Bytes Received</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes Ricevuti</translation>
     </message>
 </context>
 <context>
     <name>PeerTools</name>
     <message>
         <source>Error: Peer-to-peer functionality missing or disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore: funzionalitá peer-to-peer mancante o disabilitata.</translation>
     </message>
     <message>
         <source>Attempted to one try node.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tentativo singolo di connessione al nodo.</translation>
     </message>
     <message>
         <source>Error: Node already added</source>
-        <translation type="unfinished"></translation>
+        <translation>Nodo giá aggiunto</translation>
     </message>
     <message>
         <source>Node not found in connected nodes</source>
-        <translation type="unfinished"></translation>
+        <translation>Nodo non trovato tra i nodi connessi</translation>
     </message>
     <message>
         <source>Disconnected the node: </source>
-        <translation type="unfinished"></translation>
+        <translation>Nodo disconnesso:</translation>
     </message>
     <message>
         <source>Returned OK.</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1861,27 +1861,27 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>%1 B</source>
-        <translation type="unfinished">%1 B</translation>
+        <translation>%1 B</translation>
     </message>
     <message>
         <source>%1 TB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 TB</translation>
     </message>
     <message>
         <source>%1 GB</source>
-        <translation type="unfinished">%1 GB</translation>
+        <translation>%1 GB</translation>
     </message>
     <message>
         <source>%1 MB</source>
-        <translation type="unfinished">%1 MB</translation>
+        <translation>%1 MB</translation>
     </message>
     <message>
         <source>%1 KB</source>
-        <translation type="unfinished">%1 KB</translation>
+        <translation>%1 KB</translation>
     </message>
     <message>
         <source>%1 didn&apos;t yet exit safely...</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 non si é ancora chiuso...</translation>
     </message>
 </context>
 <context>
@@ -1892,11 +1892,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore: la cartella dati &quot;%1&quot; non esiste.</translation>
     </message>
     <message>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore: Impossibile processare il file: %1. Utilizzare unicamente la sintassi key=value.</translation>
     </message>
 </context>
 <context>
@@ -2202,55 +2202,55 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Connected peers</source>
-        <translation type="unfinished"></translation>
+        <translation>Peers collegati</translation>
     </message>
     <message>
         <source>Add new peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi peer</translation>
     </message>
     <message>
         <source>Remove peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi peer</translation>
     </message>
     <message>
         <source>One try peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Peer con tentativo singolo di connessione</translation>
     </message>
     <message>
         <source>Min Ping</source>
-        <translation type="unfinished"></translation>
+        <translation>Ping Minimo</translation>
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished"></translation>
+        <translation>Bandisci per</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi ban</translation>
     </message>
     <message>
         <source>WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramification of a command.</source>
-        <translation type="unfinished"></translation>
+        <translation>ATTENZIONE: Truffatori potrebbero tentare di convincere utenti inesperti ad utilizzare comandi che permettono di rubare il contenuto del loro portafoglio. Non usare questa console senza essere a completa conoscenza dei rischi insiti in un comando.</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Attività di rete disabilitata</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Errore</translation>
+        <translation>Errore</translation>
     </message>
     <message>
         <source>Remove Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi Peer</translation>
     </message>
     <message>
         <source>Are you sure you want to remove the peer: </source>
-        <translation type="unfinished"></translation>
+        <translation>Sei sicuro di volere rimuovere il peer: </translation>
     </message>
     <message>
         <source>No peer was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessun peer selezionato.</translation>
     </message>
 </context>
 <context>
@@ -2388,11 +2388,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;URI generato é troppo lungo. Riduci la lunghezza del testo.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore nella codifica dell&apos;URI nel codice QR.</translation>
     </message>
 </context>
 <context>
@@ -2534,7 +2534,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Dust:</source>
-        <translation>Trascurabile:</translation>
+        <translation>Polvere (dust):</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2574,7 +2574,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Copy dust</source>
-        <translation>Copia trascurabile</translation>
+        <translation>Copia polvere</translation>
     </message>
     <message>
         <source>Copy change</source>
@@ -2622,71 +2622,71 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;utilizzo del fallbackfee (commissione di transazione di riserva) può causare l&apos;invio di transazioni che impiegano ore o giorni prima di essere confermate. Prendi in considerazione la possibilitá di scegliere le commissioni di transazione manualmente o di attendere che l&apos;intera chain sia stata convalidata.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished"></translation>
+        <translation>Attenzione: Non é possibile calcolare le commissioni di transazione in questo momento.</translation>
     </message>
     <message>
         <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 satoshis in fee, while &quot;total at least&quot; pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se le commissioni di transazione sono configurate per essere 1000 satoshi e la transazione é solo 250 bytes, allora, per kilobyte, la commissione sará solamente di 250 satoshi, mente il totale sará di almeno 1000 satoshi. Per transazioni più grandi di un kilobyte entrambi pagano per kilobyte.</translation>
     </message>
     <message>
         <source>Priority:</source>
-        <translation type="unfinished"></translation>
+        <translation>Priorità</translation>
     </message>
     <message>
         <source>low</source>
-        <translation type="unfinished"></translation>
+        <translation>bassa</translation>
     </message>
     <message>
         <source>high</source>
-        <translation type="unfinished"></translation>
+        <translation>alta</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sei sicuro di voler inviare?</translation>
     </message>
     <message>
         <source>Total Amount %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Importo Totale %1</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma invio</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;indirizzo del destinatario non é valido, controlla di nuovo.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;importo da inviare deve essere superiore a 0.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il totale è superiore al saldo disponibile quando le commissioni di transazione di %1 sono incluse.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo già inserito: lo stesso indirizzo può essere inserito solo una volta.</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished"></translation>
+        <translation>Commissioni di transazione superiori a %1 sono irragionevolmente alte.</translation>
     </message>
     <message>
         <source>Pay only the required fee of %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Paga solo le commissioni di transazione richieste di %1</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma l&apos;indirizzo di scambio</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;indirizzo che hai selezionato come indirizzo di scambio non é parte di questo portafoglio. Parte o tutti i tuoi fondi potrebbero essere inviati a questo indirizzo. Sei sicuro?</translation>
     </message>
 </context>
 <context>
@@ -2769,7 +2769,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Enter a label for this address to add it to your address book</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un&apos;etichetta per questo indirizzo da aggiungere alla tua rubrica</translation>
     </message>
 </context>
 <context>
@@ -2890,7 +2890,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation>Sblocco del portamonete annullato.</translation>
+        <translation>Sblocco del portafoglio annullato.</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
@@ -2926,7 +2926,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
-        <translation type="unfinished"></translation>
+        <translation>Clicca &quot;Firma Messaggio&quot; per generare una firma.</translation>
     </message>
 </context>
 <context>
@@ -2940,39 +2940,39 @@ p, li { white-space: pre-wrap; }
     <name>TestPeerDialog</name>
     <message>
         <source>Test Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Testa il Peer</translation>
     </message>
     <message>
         <source>Enter the peer details below.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci i dettagli del peer.</translation>
     </message>
     <message>
         <source>Be careful! Do not blindly trust anyone that tells you to add their node.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fai attenzione! Non fidarti automaticamente di qualcuno che ti chiede di aggiungere il suo nodo.</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s address</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi l&apos;indirizzo del peer</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s port</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi la porta del peer</translation>
     </message>
     <message>
         <source>Test!</source>
-        <translation type="unfinished"></translation>
+        <translation>Inizia il test!</translation>
     </message>
     <message>
         <source>Please enter an address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un indirizzo.</translation>
     </message>
     <message>
         <source>Please enter a valid peer address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un indirizzo valido per il peer.</translation>
     </message>
     <message>
         <source>Try Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Prova il Peer</translation>
     </message>
 </context>
 <context>
@@ -3118,52 +3118,52 @@ p, li { white-space: pre-wrap; }
     </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Aperta per %n altro blocco</numerusform>
+            <numerusform>Aperta per altri %n blocchi</numerusform>
         </translation>
     </message>
     <message>
         <source>Open until %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Aperta fino a: %1</translation>
     </message>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
-        <translation type="unfinished"></translation>
+        <translation>Incontrati conflitti con una transazione con %1 conferme</translation>
     </message>
     <message>
         <source>in memory pool</source>
-        <translation type="unfinished"></translation>
+        <translation>nella riserva di memoria</translation>
     </message>
     <message>
         <source>not in memory pool</source>
-        <translation type="unfinished"></translation>
+        <translation>non nella riserva di memoria</translation>
     </message>
     <message numerus="yes">
         <source>, broadcast through %n node(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>, trasmessa attraverso %n nodo</numerusform>
+            <numerusform>, trasmessa attraverso %n nodi</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>matura in %n blocco</numerusform>
+            <numerusform>matura in %n blocchi</numerusform>
         </translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensione totale della transazione</translation>
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished"></translation>
+        <translation>Indice di output</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished"></translation>
+        <translation>I dogecoin generati devono maturare ancora per %1 blocchi prima di essere spendibili. Dopo essere stato generato, questo blocco è stato trasmesso alla rete per essere aggiunto alla block chain. Se l&apos;inserimento nella block chain dovesse fallire, il suo stato cambierà a "non accettato" e i dogecoin non saranno spendibili. Alle volte, questo può accadere nel caso in cui un altro nodo generi un blocco entro pochi secondi dal tuo.</translation>
     </message>
 </context>
 <context>
@@ -3174,7 +3174,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Details for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Dettagli per %1</translation>
     </message>
 </context>
 <context>
@@ -3265,34 +3265,34 @@ p, li { white-space: pre-wrap; }
     </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Aperta per %n altro blocco</numerusform>
+            <numerusform>Aperta per altri %n blocchi</numerusform>
         </translation>
     </message>
     <message>
         <source>Open until %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Aperta fino a: %1</translation>
     </message>
     <message>
         <source>Abandoned</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbandonata</translation>
     </message>
     <message>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished"></translation>
+        <translation>In conferma (%1 su %2 conferme raccomandate)</translation>
     </message>
     <message>
         <source>Conflicted</source>
-        <translation type="unfinished"></translation>
+        <translation>In conflitto</translation>
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Immatura (%1 conferme totali, disponibile fra %2)</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished"></translation>
+        <translation>Ricevuta da</translation>
     </message>
 </context>
 <context>
@@ -3443,11 +3443,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Abandon transaction</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbandona transazione</translation>
     </message>
     <message>
         <source>Copy full transaction details</source>
-        <translation type="unfinished"></translation>
+        <translation>Copia tutti i dettagli della transazione</translation>
     </message>
 </context>
 <context>
@@ -3461,7 +3461,7 @@ p, li { white-space: pre-wrap; }
     <name>WalletFrame</name>
     <message>
         <source>No wallet has been loaded.</source>
-        <translation>Non è stato caricato alcun portamonete.</translation>
+        <translation>Non è stato caricato alcun portafoglio.</translation>
     </message>
 </context>
 <context>
@@ -3495,7 +3495,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation>Si è verificato un errore durante il salvataggio dei dati del portamonete in %1.</translation>
+        <translation>Si è verificato un errore durante il salvataggio dei dati del portafoglio in %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
@@ -3503,7 +3503,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation>Il portamonete è stato correttamente salvato in %1.</translation>
+        <translation>Il portafoglio è stato correttamente salvato in %1.</translation>
     </message>
 </context>
 <context>
@@ -3590,7 +3590,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>Elimina tutte le transazioni dal portamonete e recupera solo quelle che fanno parte della blockchain attraverso il comando -rescan all&apos;avvio.</translation>
+        <translation>Elimina tutte le transazioni dal portafoglio e recupera solo quelle che fanno parte della blockchain attraverso il comando -rescan all&apos;avvio.</translation>
     </message>
     <message>
         <source>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</source>
@@ -3602,7 +3602,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Esegue un comando quando lo stato di una transazione del portamonete cambia (%s in cmd è sostituito da TxID)</translation>
+        <translation>Esegue un comando quando lo stato di una transazione del portafoglio cambia (%s in cmd è sostituito da TxID)</translation>
     </message>
     <message>
         <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
@@ -3690,7 +3690,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>Disabilita il portamonete e le relative chiamate RPC</translation>
+        <translation>Disabilita il portafoglio e le relative chiamate RPC</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -3722,7 +3722,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation>Errore durante l&apos;inizializzazione dell&apos;ambiente del database del portamonete %s!</translation>
+        <translation>Errore durante l&apos;inizializzazione dell&apos;ambiente del database del portafoglio %s!</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -3838,7 +3838,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Specify wallet file (within data directory)</source>
-        <translation>Specifica il file del portamonete (all&apos;interno della cartella dati)</translation>
+        <translation>Specifica il file del portafoglio (all&apos;interno della cartella dati)</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -3874,11 +3874,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Verifying wallet...</source>
-        <translation>Verifica portamonete...</translation>
+        <translation>Verifica portafoglio...</translation>
     </message>
     <message>
         <source>Wallet %s resides outside data directory %s</source>
-        <translation>Il portamonete %s si trova al di fuori dalla cartella dati %s</translation>
+        <translation>Il portafoglio %s si trova al di fuori dalla cartella dati %s</translation>
     </message>
     <message>
         <source>Wallet debugging/testing options:</source>
@@ -3886,11 +3886,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation>Il portamonete necessita di essere riscritto: riavviare %s per completare</translation>
+        <translation>Il portafoglio necessita di essere riscritto: riavviare %s per completare</translation>
     </message>
     <message>
         <source>Wallet options:</source>
-        <translation>Opzioni portamonete:</translation>
+        <translation>Opzioni portafoglio:</translation>
     </message>
     <message>
         <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
@@ -3906,7 +3906,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>Crea nuovi file con i permessi di default del sistema, invece che con umask 077 (ha effetto solo con funzionalità di portamonete disabilitate)</translation>
+        <translation>Crea nuovi file con i permessi di default del sistema, invece che con umask 077 (ha effetto solo con funzionalità di portafoglio disabilitate)</translation>
     </message>
     <message>
         <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
@@ -4094,7 +4094,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Zapping all transactions from wallet...</source>
-        <translation>Eliminazione dal portamonete di tutte le transazioni...</translation>
+        <translation>Eliminazione dal portafoglio di tutte le transazioni...</translation>
     </message>
     <message>
         <source>ZeroMQ notification options:</source>
@@ -4214,7 +4214,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Make the wallet broadcast transactions</source>
-        <translation>Configura il portamonete per la trasmissione di transazioni</translation>
+        <translation>Configura il portafoglio per la trasmissione di transazioni</translation>
     </message>
     <message>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
@@ -4286,11 +4286,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Loading wallet...</source>
-        <translation>Caricamento portamonete...</translation>
+        <translation>Caricamento portafoglio...</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
-        <translation>Non è possibile effettuare il downgrade del portamonete</translation>
+        <translation>Non è possibile effettuare il downgrade del portafoglio</translation>
     </message>
     <message>
         <source>Cannot write default address</source>
@@ -4310,187 +4310,187 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Bitcoin Core and Dogecoin Core</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitcoin Core e Dogecoin Core</translation>
     </message>
     <message>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
-        <translation type="unfinished"></translation>
+        <translation>Accetta connessioni esterne (default: 1 se le opzioni -proxy e -connect/-noconnect non sono specificate)</translation>
     </message>
     <message>
         <source>Amount under which a transaction output is considered dust, in %s (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Valore minimo sotto il quale l&apos;output di una transazione deve essere considerato polvere (dust), in %s (default: %s)</translation>
     </message>
     <message>
         <source>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
-        <translation type="unfinished"></translation>
+        <translation>Connettiti solo con i nodi specificati; usa -noconnect o -connect=0 per disabilitare le connessioni automatiche.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished"></translation>
+        <translation>Distribuito ai sensi della licenza software MIT. Per informazioni leggere il file %s o la pagina %s</translation>
     </message>
     <message>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash, %i is replaced by block number)</source>
-        <translation type="unfinished"></translation>
+        <translation>Esegui il comando quando l&apos;ultimo miglior blocco cambia (%s nel comando verrá sostituito con l&apos;hash del blocco, %i verrá sostituito con il numero del blocco)</translation>
     </message>
     <message>
         <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Transazioni aggiuntive da tenere in memoria per la ricostruzione dei blocchi (default: %u)</translation>
     </message>
     <message>
         <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation type="unfinished"></translation>
+        <translation>Trasmetti le transazioni inviate dai peers nella whitelist anche se violano le regole di relay locali (default: %d)</translation>
     </message>
     <message>
         <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Se giá incluso nella blockchain, considera questo blocco e i blocchi antecedenti validi e ometti la verifica degli script (0 per verificare tutti i blocchi, default: %s, testnet: %s)</translation>
     </message>
     <message>
         <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)</source>
-        <translation type="unfinished"></translation>
+        <translation>Richiedi indirizzi peers tramite lookup DNS, se sono disponibili solo pochi peers (default: 1 nel caso in cui le opzioni -connect/-noconnect non siano specificate)</translation>
     </message>
     <message>
         <source>Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -rescan. Warning: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, &gt;%u = automatically prune block files to stay under the specified target size in MiB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Riduci lo spazio occupato su disco abilitando la cancellazione (pruning) dei blocchi più vecchi. Questo permette l&apos;utilizzazione del comando RPC pruneblockchain per cancellare blocchi specifici, e abilita la cancellazione automatica dei blocchi più vecchi se viene specificato un target massimo per lo spazio occupato su disco in MiB. Questa modalitá é incompatibile con -txindex e -rescan. Attenzione: la modifica di questa opzione richiede una nuova sincronizzazione dell&apos;intera blockchain con la rete. (default: 0 = disabilita cancellazione dei blocchi, 1 = abilita cancellazione dei blocchi via RPC, &gt;%u = cancella automaticamente i file dei blocchi per rimanere al di sotto del target massimo specificato in MiB)</translation>
     </message>
     <message>
         <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci la commissione minima (in %s/kB) per l&apos;inclusione delle transazioni nei blocchi. (default: %s)</translation>
     </message>
     <message>
         <source>Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta la serializzazione delle transazioni raw e dei blocchi esadecimali in modalitá non-verbosa, non-segwit (0) o segwit (1) (default: %d)</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished"></translation>
+        <translation>Il presente software è una versione preliminare - ogni uso é a proprio rischio e pericolo. Non utilizzare per il mining o per applicazioni a scopo commerciale</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished"></translation>
+        <translation>Questa é la commissione di transazione utilizzata quando il calcolo automatico delle commissioni non é disponibile.</translation>
     </message>
     <message>
         <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard. Paper wallet art provided by Anacoluthia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Questo prodotto include software sviluppato dall&apos;OpenSSL Project per l&apos;utilizzazione nel Toolkit OpenSSL %s e in software crittografico creato da Eric Young e software UPnP creato da Tomas Bernard. Gli elementi grafici nei portafogli cartacei sono stati creati da Anacoluthia.</translation>
     </message>
     <message>
         <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
-        <translation type="unfinished"></translation>
+        <translation>Il nome utente e l&apos;hash della password per connessioni JSON-RPC. Il campo &lt;userpw&gt; deve essere nel formato: &lt;NOMEUTENTE&gt;:&lt;SALT&gt;$&lt;HASH&gt;. Uno script python per la generazione del campo é incluso nella cartella share/rpcuser. Il client può successivamente connettersi normalmente utilizzando le opzioni rpcuser=&lt;NOMEUTENTE&gt;/rpcpassword=&lt;PASSWORD&gt;. L&apos;opzione può essere specificata varie volte.</translation>
     </message>
     <message>
         <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Il portafoglio eviterà di generare transazioni che violano i limiti della mempool chain (default: %u)</translation>
     </message>
     <message>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation type="unfinished"></translation>
+        <translation>Attenzione: La rete sembra essere in disaccordo! Alcuni miner sembrano avere problemi.</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished"></translation>
+        <translation>Attenzione: Impossibile accordarsi con i peers! Potrebbe essere necessario aggiornare il nodo, o gli altri nodi potrebbero dover aggiornare il proprio software.</translation>
     </message>
     <message>
         <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi i peers che si connettono da indirizzi IP predefiniti (e.g. 1.2.3.4) o da reti specificate in notazione CIDR (e.g. 1.2.3.0/24).</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished"></translation>
+        <translation>Il valore %s é molto alto!</translation>
     </message>
     <message>
         <source>Amaze</source>
-        <translation type="unfinished"></translation>
+        <translation>Fantastico</translation>
     </message>
     <message>
         <source>Chain selection options:</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona una chain:</translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation>Default</translation>
     </message>
     <message>
         <source>Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished"></translation>
+        <translation>La keypool é vuota, usa keypoolrefill prima di continuare</translation>
     </message>
     <message>
         <source>Many generous</source>
-        <translation type="unfinished"></translation>
+        <translation>Molto generoso</translation>
     </message>
     <message>
         <source>Minimum</source>
-        <translation type="unfinished"></translation>
+        <translation>Minimo</translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"></translation>
+        <translation>Continua</translation>
     </message>
     <message>
         <source>Receive and display P2P network alerts (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ricevi e mostra avvisi relativi alla reta P2P (default: %u)</translation>
     </message>
     <message>
         <source>Send transactions with full-RBF opt-in enabled (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Invia transazioni che supportano l&apos;opzione di sostituzione con commissione (RBF) (default: %u)</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
-        <translation type="unfinished"></translation>
+        <translation>Inizializzazione dei thread di rete...</translation>
     </message>
     <message>
         <source>Such expensive</source>
-        <translation type="unfinished"></translation>
+        <translation>Costosissimo!</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il portafoglio preverrá il pagamento di commissioni inferiori alle commissioni minime</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished"></translation>
+        <translation>Questa é la commissione minima da pagare per ogni transazione.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished"></translation>
+        <translation>Questa é la commissione che pagherai quando invii una transazione.</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished"></translation>
+        <translation>Il totale della transazione non può essere negativo.</translation>
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished"></translation>
+        <translation>La transazione ha una mempool chain troppo lunga</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished"></translation>
+        <translation>La transazione deve avere almeno un destinatario</translation>
     </message>
     <message>
         <source>Use the test chain</source>
-        <translation type="unfinished"></translation>
+        <translation>Usa la test chain</translation>
     </message>
     <message>
         <source>Wow</source>
-        <translation type="unfinished"></translation>
+        <translation>Wow</translation>
     </message>
     <message>
         <source>-discardthreshold is set very high! This is the output amount that the wallet will discard (to fee) if it is smaller than this setting.</source>
-        <translation type="unfinished"></translation>
+        <translation>-discardthreshold é molto alto! Il wallet rifiuterá qualsiasi transazione se é più piccola di questo valore.</translation>
     </message>
     <message>
         <source>Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Quantitá al di sotto della quale un output di transazione deve considerarsi non standard e quindi non accettato e non trasmesso, in %s (default: %s)</translation>
     </message>
     <message>
         <source>Invalid amount for -discardthreshold=&lt;amount&gt;: &apos;%s&apos; (must be at least the dust limit of %s to prevent stuck transactions)</source>
-        <translation type="unfinished"></translation>
+        <translation>Valore invalido per -discardthreshold=&lt;valore&gt;: &apos;%s&apos; (deve essere almeno uguale al limite di polvere %s per evitare il blocco involontario delle transazioni)</translation>
     </message>
     <message>
         <source>The minimum transaction output size (in %s) used to validate wallet transactions and discard change (to fee) (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Il valore minimo di un output di transazione (in %s) utilizzato per convalidare le transazioni del portafoglio e il cambio (default: %s)</translation>
     </message>
     <message>
         <source>Use Namecoin-compatible AuxPow API structure, (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilizza la struttura API AuxPow compatibile con Namecoin, (default: %u)</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_it_IT.ts
+++ b/src/qt/locale/bitcoin_it_IT.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation>Click destro per modificare indirizzo o etichetta</translation>
+        <translation>Clicca pulsante destro per modificare indirizzo o etichetta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -84,7 +84,7 @@
     </message>
     <message>
         <source>Banned Until</source>
-        <translation>bannato fino </translation>
+        <translation>Bannato fino </translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Full italian translation of all missing phrases. Some notes:

- I shifted to using "portafoglio" instead of "portamonete" to refer to "wallet" as this is what is traditionally used in other wallets and somehow feels more correct or current to me.
- For the term "dust" I opted for the more literal Italian translation "polvere" as it is how this is commonly referred to on italian tutorials/websites. I added (dust) next to polvere to allow people to be able to understand that "dust" RPC commands are referring to the same concept.